### PR TITLE
Fix: Github Actions 빌드 에러 v1.1.0+5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,9 @@ jobs:
       # install dependencies
       - name: install dependencies
         run: flutter pub get
+      # generate code
+      - name: generate code
+        run: dart run build_runner build --delete-conflicting-outputs
       # setup keystore for android build
       - name: Decode Keystore
         run: |


### PR DESCRIPTION
- Riverpod Generator가 생성하는 코드가 git에서 제외되면서 발생한 에러